### PR TITLE
Block downloads.zdnet.de instead of www.zdnet.com & zdnet.com

### DIFF
--- a/filterlist-abp.txt
+++ b/filterlist-abp.txt
@@ -1,11 +1,11 @@
 [Adblock Plus]
 ! Title: FMHY Unsafe sites filterlist - Plus
 ! Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-! Last modified: 24 Dec 2024 17:45 UTC
+! Last modified: 27 Dec 2024 22:23 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues
-! Entries: 311
+! Entries: 310
 ! Expires: 4 days
 ! Format: abp
 
@@ -290,8 +290,7 @@
 ||cnet.com^
 ||download.cnet.com^
 ||download.com^
-||www.zdnet.com^
-||zdnet.com^
+||downloads.zdnet.de^
 ||en.softonic.com^
 ||softonic.com^
 ! Software / Apps

--- a/filterlist-basic-abp.txt
+++ b/filterlist-basic-abp.txt
@@ -1,7 +1,7 @@
 [Adblock Plus]
 ! Title: FMHY Unsafe sites filterlist - Basic
 ! Description: Blocks malicious sites listed in the fmhy unsafe sites page
-! Last modified: 24 Dec 2024 17:45 UTC
+! Last modified: 27 Dec 2024 22:23 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues

--- a/filterlist-basic-domains.txt
+++ b/filterlist-basic-domains.txt
@@ -1,6 +1,6 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues

--- a/filterlist-basic-hosts.txt
+++ b/filterlist-basic-hosts.txt
@@ -1,6 +1,6 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues

--- a/filterlist-basic-wildcard-domains.txt
+++ b/filterlist-basic-wildcard-domains.txt
@@ -1,6 +1,6 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues

--- a/filterlist-basic-wildcard-urls.txt
+++ b/filterlist-basic-wildcard-urls.txt
@@ -1,6 +1,6 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues

--- a/filterlist-basic.txt
+++ b/filterlist-basic.txt
@@ -1,6 +1,6 @@
 ! Title: FMHY Unsafe sites filterlist - Basic
 ! Description: Blocks malicious sites listed in the fmhy unsafe sites page
-! Last modified: 24 Dec 2024 17:45 UTC
+! Last modified: 27 Dec 2024 22:23 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues

--- a/filterlist-domains.txt
+++ b/filterlist-domains.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 311
+# Entries: 310
 # Expires: 4 days
 # Format: domains
 
@@ -289,8 +289,7 @@ www.cnet.com
 cnet.com
 download.cnet.com
 download.com
-www.zdnet.com
-zdnet.com
+downloads.zdnet.de
 en.softonic.com
 softonic.com
 # Software / Apps

--- a/filterlist-hosts.txt
+++ b/filterlist-hosts.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 311
+# Entries: 310
 # Expires: 4 days
 # Format: hosts
 
@@ -289,8 +289,7 @@
 0.0.0.0 cnet.com
 0.0.0.0 download.cnet.com
 0.0.0.0 download.com
-0.0.0.0 www.zdnet.com
-0.0.0.0 zdnet.com
+0.0.0.0 downloads.zdnet.de
 0.0.0.0 en.softonic.com
 0.0.0.0 softonic.com
 # Software / Apps

--- a/filterlist-wildcard-domains.txt
+++ b/filterlist-wildcard-domains.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 311
+# Entries: 310
 # Expires: 4 days
 # Format: wildcard_domains
 
@@ -289,8 +289,7 @@
 *.cnet.com
 *.download.cnet.com
 *.download.com
-*.www.zdnet.com
-*.zdnet.com
+*.downloads.zdnet.de
 *.en.softonic.com
 *.softonic.com
 # Software / Apps

--- a/filterlist-wildcard-urls.txt
+++ b/filterlist-wildcard-urls.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 24 Dec 2024 17:45 UTC
+# Last modified: 27 Dec 2024 22:23 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 311
+# Entries: 310
 # Expires: 4 days
 # Format: wildcard_urls
 
@@ -289,8 +289,7 @@
 *://*.cnet.com/*
 *://*.download.cnet.com/*
 *://*.download.com/*
-*://*.www.zdnet.com/*
-*://*.zdnet.com/*
+*://*.downloads.zdnet.de/*
 *://*.en.softonic.com/*
 *://*.softonic.com/*
 # Software / Apps

--- a/filterlist.txt
+++ b/filterlist.txt
@@ -1,10 +1,10 @@
 ! Title: FMHY Unsafe sites filterlist - Plus
 ! Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-! Last modified: 24 Dec 2024 17:45 UTC
+! Last modified: 27 Dec 2024 22:23 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues
-! Entries: 347
+! Entries: 346
 ! Expires: 4 days
 ! Format: ublock
 
@@ -289,8 +289,7 @@
 ||cnet.com^
 ||download.cnet.com^
 ||download.com^
-||www.zdnet.com^
-||zdnet.com^
+||downloads.zdnet.de^
 ||en.softonic.com^
 ||softonic.com^
 ! Software / Apps

--- a/sitelist-plus.txt
+++ b/sitelist-plus.txt
@@ -4,8 +4,7 @@ www.cnet.com
 cnet.com
 download.cnet.com
 download.com
-www.zdnet.com
-zdnet.com
+downloads.zdnet.de
 en.softonic.com
 softonic.com
 ! Software / Apps


### PR DESCRIPTION
ZDNet itself is a legitimate news website. It looks like they previously operated a sketchy download service, which I'm assuming is why they're blocked here - but this no longer seems to be the case.

**That being said**: It appears that the sketchy download service is still up for the German version of their website *(though hasn't been updated since 2022...)*, so we should still block it specifically, rather than ZDNet as a whole: `downloads.zdnet.de`.