### PR TITLE
Remove 'cracked-games.org' from filterlists

### DIFF
--- a/filterlists-reasons.json
+++ b/filterlists-reasons.json
@@ -19,7 +19,6 @@
   "blackboxrepacke.com": "Fake BlackBox Repacks, contain malware - https://rentry.org/pgames#untrusted-uploaders",
   "crackingpatching.com": "Caught with malware - https://redd.it/qy6z3c",
   "crackingpatching.org": "Caught with malware - https://redd.it/qy6z3c",
-  "cracked-games.org": "Caught with malware - https://rentry.org/pgames#untrusted-uploaders",
   "www.wifi4games.com": "Caught with malware - https://rentry.org/pgames#untrusted-uploaders",
   "wifi4games.com": "Caught with malware - https://rentry.org/pgames#untrusted-uploaders",
   "wifi4games.net": "Caught with malware - https://rentry.org/pgames#untrusted-uploaders",


### PR DESCRIPTION
Removed entry for 'cracked-games.org' due to being considered safe now.