### PR TITLE
Remove cracked-games entry from filterlist

### DIFF
--- a/filterlist-basic.txt
+++ b/filterlist-basic.txt
@@ -322,7 +322,6 @@
 ||aimhaven.*^$all
 ||oceanofgames.*^$all
 ||crackingpatching.*^$all
-||*cracked-games.*^$all
 ||*getintopc.com^$all
 ||*softonic.*^$all
 ||iobit.*^$all


### PR DESCRIPTION
cracked-games.org is considered safe now