### PR TITLE
cracked-games.org removed

### DIFF
--- a/filterlist.txt
+++ b/filterlist.txt
@@ -371,7 +371,6 @@
 ||aimhaven.*^$all
 ||oceanofgames.*^$all
 ||crackingpatching.*^$all
-||*cracked-games.*^$all
 ||*getintopc.com^$all
 ||*softonic.*^$all
 ||iobit.*^$all


### PR DESCRIPTION
cracked-games.org considered safe now