### PR TITLE
This PR updates the SteamUnlocked entry by adding the currently active domain (steamunlocked.org) alongside the existing steamunlocked.net entry to reflect current availability without assuming a permanent migration.

### DIFF
--- a/filterlist-abp.txt
+++ b/filterlist-abp.txt
@@ -1,11 +1,11 @@
 [Adblock Plus]
 ! Title: FMHY Unsafe sites filterlist - Plus
 ! Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-! Last modified: 06 Jun 2026 02:47 UTC
+! Last modified: 07 Jun 2026 22:32 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues
-! Entries: 329
+! Entries: 330
 ! Expires: 4 days
 ! Format: abp
 
@@ -38,6 +38,7 @@
 ||gamefabrique.com^
 ||gamefabrique.ru^
 ||steamunlocked.net^
+||steamunlocked.org^
 ||game-repack.site^
 ! Pirate bay proxies And clones
 ! thepiratebay.org

--- a/filterlist-basic-abp.txt
+++ b/filterlist-basic-abp.txt
@@ -1,11 +1,11 @@
 [Adblock Plus]
 ! Title: FMHY Unsafe sites filterlist - Basic
 ! Description: Blocks malicious sites listed in the fmhy unsafe sites page
-! Last modified: 06 Jun 2026 02:47 UTC
+! Last modified: 07 Jun 2026 22:32 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues
-! Entries: 283
+! Entries: 284
 ! Expires: 4 days
 ! Format: abp
 
@@ -38,6 +38,7 @@
 ||gamefabrique.com^
 ||gamefabrique.ru^
 ||steamunlocked.net^
+||steamunlocked.org^
 ||game-repack.site^
 ! Pirate bay proxies And clones
 ! thepiratebay.org

--- a/filterlist-basic-domains.txt
+++ b/filterlist-basic-domains.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 283
+# Entries: 284
 # Expires: 4 days
 # Format: domains
 
@@ -37,6 +37,7 @@ wifi4games.net
 gamefabrique.com
 gamefabrique.ru
 steamunlocked.net
+steamunlocked.org
 game-repack.site
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-basic-hosts.txt
+++ b/filterlist-basic-hosts.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 283
+# Entries: 284
 # Expires: 4 days
 # Format: hosts
 
@@ -37,6 +37,7 @@
 0.0.0.0 gamefabrique.com
 0.0.0.0 gamefabrique.ru
 0.0.0.0 steamunlocked.net
+0.0.0.0 steamunlocked.org
 0.0.0.0 game-repack.site
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-basic-wildcard-domains.txt
+++ b/filterlist-basic-wildcard-domains.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 283
+# Entries: 284
 # Expires: 4 days
 # Format: wildcard_domains
 
@@ -37,6 +37,7 @@
 *.gamefabrique.com
 *.gamefabrique.ru
 *.steamunlocked.net
+*.steamunlocked.org
 *.game-repack.site
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-basic-wildcard-urls.txt
+++ b/filterlist-basic-wildcard-urls.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Basic
 # Description: Blocks malicious sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 283
+# Entries: 284
 # Expires: 4 days
 # Format: wildcard_urls
 
@@ -37,6 +37,7 @@
 *://*.gamefabrique.com/*
 *://*.gamefabrique.ru/*
 *://*.steamunlocked.net/*
+*://*.steamunlocked.org/*
 *://*.game-repack.site/*
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-basic.txt
+++ b/filterlist-basic.txt
@@ -1,10 +1,10 @@
 ! Title: FMHY Unsafe sites filterlist - Basic
 ! Description: Blocks malicious sites listed in the fmhy unsafe sites page
-! Last modified: 06 Jun 2026 02:47 UTC
+! Last modified: 07 Jun 2026 22:32 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues
-! Entries: 319
+! Entries: 320
 ! Expires: 4 days
 ! Format: ublock
 
@@ -37,6 +37,7 @@
 ||gamefabrique.com^
 ||gamefabrique.ru^
 ||steamunlocked.net^
+||steamunlocked.org^
 ||game-repack.site^
 ! Pirate bay proxies And clones
 ! thepiratebay.org

--- a/filterlist-domains.txt
+++ b/filterlist-domains.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 329
+# Entries: 330
 # Expires: 4 days
 # Format: domains
 
@@ -37,6 +37,7 @@ wifi4games.net
 gamefabrique.com
 gamefabrique.ru
 steamunlocked.net
+steamunlocked.org
 game-repack.site
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-hosts.txt
+++ b/filterlist-hosts.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 329
+# Entries: 330
 # Expires: 4 days
 # Format: hosts
 
@@ -37,6 +37,7 @@
 0.0.0.0 gamefabrique.com
 0.0.0.0 gamefabrique.ru
 0.0.0.0 steamunlocked.net
+0.0.0.0 steamunlocked.org
 0.0.0.0 game-repack.site
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-wildcard-domains.txt
+++ b/filterlist-wildcard-domains.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 329
+# Entries: 330
 # Expires: 4 days
 # Format: wildcard_domains
 
@@ -37,6 +37,7 @@
 *.gamefabrique.com
 *.gamefabrique.ru
 *.steamunlocked.net
+*.steamunlocked.org
 *.game-repack.site
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist-wildcard-urls.txt
+++ b/filterlist-wildcard-urls.txt
@@ -1,10 +1,10 @@
 # Title: FMHY Unsafe sites filterlist - Plus
 # Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-# Last modified: 06 Jun 2026 02:47 UTC
+# Last modified: 07 Jun 2026 22:32 UTC
 # Homepage: https://github.com/fmhy/FMHYFilterlist
 # License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 # Issues: https://github.com/fmhy/FMHYFilterlist/issues
-# Entries: 329
+# Entries: 330
 # Expires: 4 days
 # Format: wildcard_urls
 
@@ -37,6 +37,7 @@
 *://*.gamefabrique.com/*
 *://*.gamefabrique.ru/*
 *://*.steamunlocked.net/*
+*://*.steamunlocked.org/*
 *://*.game-repack.site/*
 # Pirate bay proxies And clones
 # thepiratebay.org

--- a/filterlist.txt
+++ b/filterlist.txt
@@ -1,10 +1,10 @@
 ! Title: FMHY Unsafe sites filterlist - Plus
 ! Description: Blocks malicious and not recommended sites listed in the fmhy unsafe sites page
-! Last modified: 06 Jun 2026 02:47 UTC
+! Last modified: 07 Jun 2026 22:32 UTC
 ! Homepage: https://github.com/fmhy/FMHYFilterlist
 ! License: https://github.com/fmhy/FMHYFilterlist/blob/main/LICENSE
 ! Issues: https://github.com/fmhy/FMHYFilterlist/issues
-! Entries: 365
+! Entries: 366
 ! Expires: 4 days
 ! Format: ublock
 
@@ -37,6 +37,7 @@
 ||gamefabrique.com^
 ||gamefabrique.ru^
 ||steamunlocked.net^
+||steamunlocked.org^
 ||game-repack.site^
 ! Pirate bay proxies And clones
 ! thepiratebay.org

--- a/sitelist.txt
+++ b/sitelist.txt
@@ -27,6 +27,7 @@ wifi4games.net
 gamefabrique.com
 gamefabrique.ru
 steamunlocked.net
+steamunlocked.org
 game-repack.site
 ! Pirate bay proxies And clones
 ! thepiratebay.org


### PR DESCRIPTION
add steamunlocked.org alongside steamunlocked.net